### PR TITLE
Add initialize method to View::Cell

### DIFF
--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -160,6 +160,20 @@ abstract class Cell
         if (!empty($cellOptions['cache'])) {
             $this->_cache = $cellOptions['cache'];
         }
+
+        $this->initialize();
+    }
+
+    /**
+     * Initialization hook method.
+     *
+     * Implement this method to avoid having to overwrite
+     * the constructor and call parent.
+     *
+     * @return void
+     */
+    public function initialize()
+    {
     }
 
     /**


### PR DESCRIPTION
I think initialize method is  convenient to have it in the View::Cell.
initialize method is having consistency across the framework.

## use case

I think that I will use `initialize()` especially when there are multiple methods.


```php
    public function __construct(
        $request = null,
        $response = null,
        $eventManager = null,
        array $cellOptions = []) {

        parent::__construct($request, $response, $eventManager, $cellOptions);

        $this->loadModel('Banners');
    }

    public function top()
    {
        $banners = $this->Banners->find('top');
        //do something
    }

    public function side()
    {
        $banners = $this->Banners->find('side');
        //do something
    }

    public function footer()
    {
        $banners = $this->Banners->find('footer');
        //do something
    }
```

↓

```php
class BannerCell extends Cell
{
    public function initialize()
    {
        $this->loadModel('Banners');
    }

    public function top()
    {
        $banners = $this->Banners->find('top');
        //do something
    }

    public function side()
    {
        $banners = $this->Banners->find('side');
        //do something
    }

    public function footer()
    {
        $banners = $this->Banners->find('footer');
        //do something
    }
}
```